### PR TITLE
Update package install suggestion for Debian

### DIFF
--- a/docs/ref/contrib/gis/install/spatialite.txt
+++ b/docs/ref/contrib/gis/install/spatialite.txt
@@ -7,9 +7,7 @@ spatial database.
 
 First, check if you can install SpatiaLite from system packages or binaries.
 
-For example, on Debian-based distributions, try to install the
-``spatialite-bin`` package. For distributions that package SpatiaLite 4.2+,
-install ``libsqlite3-mod-spatialite``.
+For example: With Debian-based distributions that package SpatiaLite 4.2+ in their recent releases (e.g Debian Stretch, Ubuntu 18.04, etc.), install ``libsqlite3-mod-spatialite``. For older releases, try to install the ``spatialite-bin`` package.
 
 For macOS, follow the :ref:`instructions below<spatialite_macos>`.
 


### PR DESCRIPTION
Debian Stretch has ships with libsqlite3-mod-spatialite version 4.3 available, thus that should be suggested first. Additionally, on Ubuntu 18.04, by means of a simple `apt install` command, `libsqlite3-mod-spatialite` worked whereas `spatialite-bin` did not.